### PR TITLE
Правка формирования массива $params 

### DIFF
--- a/assets/snippets/FormLister/core/FormLister.abstract.php
+++ b/assets/snippets/FormLister/core/FormLister.abstract.php
@@ -626,6 +626,8 @@ abstract class Core
                         } else {
                             $params = array($value, $description['params']);
                         }
+                    }elseif (isset($description['function'])) {
+                        $params = array($value, $description['params']);
                     }
                     $message = isset($description['message']) ? $description['message'] : '';
                 } else {


### PR DESCRIPTION
Правка формирования массива $params для ситуации когда у нас кастомная валидация в функции и предварительно не было валидаций