### PR TITLE
Update wrapper.php

### DIFF
--- a/assets/snippets/FormLister/lib/captcha/reCaptcha/wrapper.php
+++ b/assets/snippets/FormLister/lib/captcha/reCaptcha/wrapper.php
@@ -43,6 +43,9 @@ class ReCaptchaWrapper implements CaptchaInterface
     public function getPlaceholder()
     {
         $siteKey = \APIhelpers::getkey($this->cfg, 'siteKey');
+        $reCAPTCHAversion = \APIhelpers::getkey($this->cfg, 'reCAPTCHAversion', "2");
+		$classButton = \APIhelpers::getkey($this->cfg, 'classButton', "g-recaptcha");
+		$textButton = \APIhelpers::getkey($this->cfg, 'textButton', "Submit");
         $type = \APIhelpers::getkey($this->cfg, 'type', 'image');
         $size = \APIhelpers::getkey($this->cfg, 'size', 'normal');
         $tabindex = \APIhelpers::getkey($this->cfg, 'tabindex', 0);
@@ -54,7 +57,14 @@ class ReCaptchaWrapper implements CaptchaInterface
         $expcallback = \APIhelpers::getkey($this->cfg, 'expired_callback', '');
         $out = '';
         if (!empty($siteKey)) {
-            $out = "<div {$id} class=\"g-recaptcha\" data-sitekey=\"{$siteKey}\" data-type=\"{$type}\" data-tabindex=\"{$tabindex}\" data-size=\"{$size}\" data-theme=\"{$theme}\" data-callback=\"{$callback}\" data-expired-callback=\"{$expcallback}\" data-badge=\"{$badge}\"></div>";
+            switch($reCAPTCHAversion) {
+				case "3":
+					$out = "<button class=\"{$classButton}\" data-sitekey=\"{$siteKey}\" data-callback='onSubmit' data-action='submit'>{$textButton}</button>";
+					break;
+				default:
+					$out = "<div {$id} class=\"g-recaptcha\" data-sitekey=\"{$siteKey}\" data-type=\"{$type}\" data-tabindex=\"{$tabindex}\" data-size=\"{$size}\" data-theme=\"{$theme}\" data-callback=\"{$callback}\" data-expired-callback=\"{$expcallback}\" data-badge=\"{$badge}\"></div>";
+					break;
+			}
         }
 
         return $out;


### PR DESCRIPTION
reCaptcha v3 compatibility: I add 3 new options: reCAPTCHAversion, classButton and classButton.
We can use in the snippet call:
&captchaParams=`{
	"reCAPTCHAversion":"3",
	"siteKey":"---yoursiteKey---",
	"secretKey":"---yourSecretKey---",
	"classButton":"g-recaptcha button is-link",
	"textButton":"Envoyer",
	"errorCodeFailed":"Il y a erreur avec le reCAPTCHA"
}`
And add the script in the HTML:
<script src='https://www.google.com/recaptcha/api.js?hl=en'></script>
<script>
	function onSubmit(token) {
		document.getElementById("contactForm").submit();
	}
</script>