### PR TITLE
Update Profile.php

### DIFF
--- a/assets/snippets/FormLister/core/controller/Profile.php
+++ b/assets/snippets/FormLister/core/controller/Profile.php
@@ -181,6 +181,12 @@ class Profile extends Core
             'log'    => $this->user->getLog()
         ]);
         if ($result) {
+            if ($this->modx->getLoginUserID() && $this->getField($this->getCFGDef('rememberField', 'rememberme'))) {
+                //Updating session_id in cookie, if user is login and just saved
+                $cookieLifetime = $this->getCFGDef('cookieLifetime', 60 * 60 * 24 * 365 * 5);
+                $loginCookie = $this->getCFGDef('cookieName', 'WebLoginPE');
+                $this->user->setAutoLoginCookie($loginCookie, $cookieLifetime);
+            }
             $this->setFormStatus(true);
             $this->user->close();
             $this->setFields($this->user->edit($result)->toArray());


### PR DESCRIPTION
Добавляем поддержку параметров автологина - rememberField, cookieLifetime и cookieName.

Так как если они ранее были использованы в контроллере Login, то в этом месте после функции save() в базу пишется новый session_id, и если после этого закрыть браузер, то потом при следующем запуске не срабатывает проверка куки, так как у нее уже не совпадет session_id с сохраненным в базе данных.

Добавление этих параметров и добавление в форму поля rememberme позволяет пересохранить эту куку с актуальным session_id.