### PR TITLE
Корректируем автологин

### DIFF
--- a/assets/snippets/FormLister/plugin.userHelper.php
+++ b/assets/snippets/FormLister/plugin.userHelper.php
@@ -37,6 +37,20 @@ if ($e->name == 'OnWebLogin' && isset($userObj)) {
         $userObj->setAutoLoginCookie($cookieName, $cookieLifetime);
     }
 }
+//Updating session_id in cookie, if user is login and just saved
+if ($e->name == 'OnWebSaveUser' && isset($userObj)) {
+    if( (int)$modx->getLoginUserID('web') == (int)$id) { //checking, if current logined user was saved
+        if (isset($_COOKIE[$cookieName])) {
+            $cookieParts = explode("|", $_COOKIE[$cookieName], 4);
+            if(isset($cookieParts[2])) {
+                if ($userObj->get('sessionid') != $cookieParts[2]) { //checking, if session ids in cookie and in user object became not equals
+                    $userObj->setAutoLoginCookie($cookieName, $cookieLifetime);
+                }
+            }
+        }
+    }
+}
+
 if ($e->name == 'OnWebPageInit' || $e->name == 'OnPageNotFound') {
     $model = isset($params['model']) && class_exists($params['model']) ? $params['model'] : '\\modUsers';
     $user = new $model($modx);
@@ -64,3 +78,4 @@ if ($e->name == 'OnWebPageInit' || $e->name == 'OnPageNotFound') {
         $user->AutoLogin($cookieLifetime, $cookieName, true);
     }
 }
+

--- a/assets/snippets/FormLister/plugin.userHelper.php
+++ b/assets/snippets/FormLister/plugin.userHelper.php
@@ -39,14 +39,10 @@ if ($e->name == 'OnWebLogin' && isset($userObj)) {
 }
 //Updating session_id in cookie, if user is login and just saved
 if ($e->name == 'OnWebSaveUser' && isset($userObj)) {
-    if( (int)$modx->getLoginUserID('web') == (int)$id) { //checking, if current logined user was saved
-        if (isset($_COOKIE[$cookieName])) {
-            $cookieParts = explode("|", $_COOKIE[$cookieName], 4);
-            if(isset($cookieParts[2])) {
-                if ($userObj->get('sessionid') != $cookieParts[2]) { //checking, if session ids in cookie and in user object became not equals
-                    $userObj->setAutoLoginCookie($cookieName, $cookieLifetime);
-                }
-            }
+    if( (int)$modx->getLoginUserID('web') == (int)$id && isset($_COOKIE[$cookieName]) ) { //checking, if current logined user was saved
+        $cookieParts = explode("|", $_COOKIE[$cookieName], 4);
+        if(isset($cookieParts[2]) && ($userObj->get('sessionid') != $cookieParts[2])) { //checking, if session ids in cookie and in user object became not equals
+            $userObj->setAutoLoginCookie($cookieName, $cookieLifetime);
         }
     }
 }

--- a/install/assets/plugins/userHelper.tpl
+++ b/install/assets/plugins/userHelper.tpl
@@ -7,7 +7,7 @@
  * @category    plugin
  * @version     1.19.2
  * @internal    @properties &model=Model;text;\\modUsers &logoutKey=Request key;text;logout &cookieName=Cookie Name;text;WebLoginPE &cookieLifetime=Cookie Lifetime, seconds;text;157680000 &maxFails=Max failed logins;text;3 &blockTime=Block for, seconds;text;3600 &trackWebUserActivity=Track web user activity;list;No,Yes;No
- * @internal    @events OnWebAuthentication,OnWebPageInit,OnPageNotFound,OnWebLogin
+ * @internal    @events OnWebAuthentication,OnWebPageInit,OnPageNotFound,OnWebLogin,OnWebSaveUser
  * @internal    @modx_category Content
  * @internal    @disabled 1
 **/


### PR DESCRIPTION
Если в контроллере Login использовались параметры установления куки, то в контроллере Profile (либо других участках кода, использующих modUsers) после функции save() в базу пишется новый session_id, и если после этого закрыть браузер, то потом при следующем запуске не срабатывает проверка куки, так как у нее уже не совпадет session_id с сохраненным в базе данных.

Данный фикс добвляет в плагин UserHelper проверку события OnWebSaveUser, в котором проверяет, "испортилась" ли кука, если она не актуальна, то она устанавливается заново с актуальным идентификатором сессии.